### PR TITLE
Removing reference to connector security group as cross account looku…

### DIFF
--- a/groups/cvo/locals.tf
+++ b/groups/cvo/locals.tf
@@ -10,6 +10,12 @@ locals {
 
   internal_fqdn = format("%s.%s.aws.internal", split("-", var.aws_account)[1], split("-", var.aws_account)[0])
 
+  netapp_connector_cidrs = [
+    "10.44.12.0/24",
+    "10.44.13.0/24",
+    "10.44.14.0/24"
+  ]
+
   default_tags = {
     Terraform = "true"
     Project   = "Storage"

--- a/groups/cvo/netapp.tf
+++ b/groups/cvo/netapp.tf
@@ -25,12 +25,9 @@ module "cvo" {
   ## Security Group setting
   ingress_cidr_blocks = concat(
     local.admin_cidrs,
+    local.netapp_connector_cidrs,
     [data.aws_vpc.vpc.cidr_block]
   )
-
-  ingress_security_group_ids = [
-    format("%s/%s", local.account_ids["shared-services"], local.netapp_connector_data["occm-security-group-id"])
-  ]
 
   route_table_ids = [data.aws_route_table.default.route_table_id]
 


### PR DESCRIPTION
Removing reference to connector security group as cross account lookup fails, using CIDR for subnets as well to limit overall rules created