### PR TITLE
Adding client ips for onpremise, allowing netapp tools to communicate

### DIFF
--- a/groups/cvo/profiles/heritage-development-eu-west-2/vars
+++ b/groups/cvo/profiles/heritage-development-eu-west-2/vars
@@ -12,9 +12,20 @@ cvo_license_type            = "cot-explore-paygo"
 cvo_is_ha                   = false
 cvo_ontap_version           = "ONTAP-9.7P5.T1"
 connector_account_access_id = "CloudProviderAccount-jufYYNpi"
-client_ports                = [
-    { "protocol" = "tcp", "port" = 22 },
-    { "protocol" = "tcp", "port" = 443 },
+
+client_ips = [
+"10.10.9.0/28",
+"172.24.4.192/32",
+"172.16.200.144/29",
+"172.16.2.112/29",
+"172.21.12.92/30",
+"172.19.235.0/24"
+]
+
+client_ports = [
+    { "protocol" = "tcp", "port" = 8088 },
     { "protocol" = "tcp", "port" = 10000 },
+    { "protocol" = "tcp", "port" = 10565, "to_port" = 10569 },
+    { "protocol" = "tcp", "port" = 10670 },
     { "protocol" = "tcp", "port" = 11104, "to_port" = 11105 },
 ]

--- a/groups/cvo/profiles/heritage-live-eu-west-2/vars
+++ b/groups/cvo/profiles/heritage-live-eu-west-2/vars
@@ -18,9 +18,20 @@ cvo_floating_ips            = [
     "192.168.255.35",
     "192.168.255.36"
 ]
-client_ports                = [
-    { "protocol" = "tcp", "port" = 22 },
-    { "protocol" = "tcp", "port" = 443 },
+
+client_ips = [
+"10.10.9.0/28",
+"172.24.4.192/32",
+"172.16.200.144/29",
+"172.16.2.112/29",
+"172.21.12.92/30",
+"172.19.235.0/24"
+]
+
+client_ports = [
+    { "protocol" = "tcp", "port" = 8088 },
     { "protocol" = "tcp", "port" = 10000 },
+    { "protocol" = "tcp", "port" = 10565, "to_port" = 10569 },
+    { "protocol" = "tcp", "port" = 10670 },
     { "protocol" = "tcp", "port" = 11104, "to_port" = 11105 },
 ]

--- a/groups/cvo/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/cvo/profiles/heritage-staging-eu-west-2/vars
@@ -11,17 +11,27 @@ cvo_instance_type           = "m5.4xlarge"
 cvo_license_type            = "ha-cot-premium-paygo"
 cvo_is_ha                   = true
 cvo_ontap_version           = "ONTAP-9.7P5.T1.ha"
+connector_account_access_id = "CloudProviderAccount-AwVeHvwJ"
 cvo_floating_ips            = [
     "192.168.255.17",
     "192.168.255.18",
     "192.168.255.19",
     "192.168.255.20"
 ]
-connector_account_access_id = "CloudProviderAccount-AwVeHvwJ"
-client_ports                = [
-    { "protocol" = "tcp", "port" = 22 },
-    { "protocol" = "tcp", "port" = 443 },
-    { "protocol" = "tcp", "port" = 10000 },
-    { "protocol" = "tcp", "port" = 11104, "to_port" = 11105 },
+
+client_ips = [
+"10.10.9.0/28",
+"172.24.4.192/32",
+"172.16.200.144/29",
+"172.16.2.112/29",
+"172.21.12.92/30",
+"172.19.235.0/24"
 ]
 
+client_ports = [
+    { "protocol" = "tcp", "port" = 8088 },
+    { "protocol" = "tcp", "port" = 10000 },
+    { "protocol" = "tcp", "port" = 10565, "to_port" = 10569 },
+    { "protocol" = "tcp", "port" = 10670 },
+    { "protocol" = "tcp", "port" = 11104, "to_port" = 11105 },
+]

--- a/groups/cvo/variables.tf
+++ b/groups/cvo/variables.tf
@@ -81,16 +81,28 @@ variable "cvo_floating_ips" {
   }
 }
 
+variable "connector_account_access_id" {
+  type        = string
+  description = "The credential ID as found in the NetApp Connector credentials page, custom per account and must exist before deployment"
+  default     = null
+}
+
 variable "netapp_connector_ip" {
   type        = string
   description = "The full CIDR formatted IP of the Connector instance so that we can allow it to access CVO security groups"
   default     = "10.44.13.97/32"
 }
 
-variable "connector_account_access_id" {
+variable "netapp_unifiedmanager_ip" {
   type        = string
-  description = "The credential ID as found in the NetApp Connector credentials page, custom per account and must exist before deployment"
-  default     = null
+  description = "The full CIDR formatted IP of the Unified Manager instance so that we can allow it to access CVO security groups"
+  default     = "10.44.13.208/32"
+}
+
+
+variable "client_ips" {
+  type        = list(any)
+  description = "The full CIDR formatted IPs of the client networks that need to access CVO"
 }
 
 variable "client_ports" {


### PR DESCRIPTION
Adding client ips for onpremise, allowing netapp tools to communicateopenly but specific IPs, limit icmp to single range