### PR TITLE
Allow Additional SVM ICMP Access

### DIFF
--- a/groups/cvo/netapp.tf
+++ b/groups/cvo/netapp.tf
@@ -77,7 +77,7 @@ resource "aws_security_group_rule" "onpremise_icmp" {
   from_port   = "-1"
   to_port     = "-1"
   protocol    = "icmp"
-  cidr_blocks = ["172.19.235.0/24"]
+  cidr_blocks = var.client_ips_icmp
 }
 
 resource "aws_security_group_rule" "onpremise_admin" {

--- a/groups/cvo/profiles/heritage-development-eu-west-2/vars
+++ b/groups/cvo/profiles/heritage-development-eu-west-2/vars
@@ -22,6 +22,11 @@ client_ips = [
 "172.19.235.0/24"
 ]
 
+client_ips_icmp = [
+"172.19.235.0/24",
+"10.10.9.0/28"
+]
+
 client_ports = [
     { "protocol" = "tcp", "port" = 8088 },
     { "protocol" = "tcp", "port" = 10000 },

--- a/groups/cvo/profiles/heritage-live-eu-west-2/vars
+++ b/groups/cvo/profiles/heritage-live-eu-west-2/vars
@@ -28,6 +28,11 @@ client_ips = [
 "172.19.235.0/24"
 ]
 
+client_ips_icmp = [
+"172.19.235.0/24",
+"10.10.9.0/28"
+]
+
 client_ports = [
     { "protocol" = "tcp", "port" = 8088 },
     { "protocol" = "tcp", "port" = 10000 },

--- a/groups/cvo/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/cvo/profiles/heritage-staging-eu-west-2/vars
@@ -28,6 +28,11 @@ client_ips = [
 "172.19.235.0/24"
 ]
 
+client_ips_icmp = [
+"172.19.235.0/24",
+"10.10.9.0/28"
+]
+
 client_ports = [
     { "protocol" = "tcp", "port" = 8088 },
     { "protocol" = "tcp", "port" = 10000 },

--- a/groups/cvo/variables.tf
+++ b/groups/cvo/variables.tf
@@ -105,6 +105,11 @@ variable "client_ips" {
   description = "The full CIDR formatted IPs of the client networks that need to access CVO"
 }
 
+variable "client_ips_icmp" {
+  type        = list(any)
+  description = "The full CIDR formatted IPs of the client networks that need ICMP connectivity to CVO"
+}
+
 variable "client_ports" {
   type        = list(any)
   description = "A list of ports to allow from on-premise ranges"


### PR DESCRIPTION
Added new `client_ips_icmp` variable to define a list of CIDRs requiring ICMP access
Added `client_ips_icmp` to all profiles and populated list
Updated `onpremise_icmp` security group resource to use `client_ips_icmp` variable

Ref: INC0327720