### PR TITLE
Allow backend to access Staging via NFS and CIFS

### DIFF
--- a/groups/cvo/netapp.tf
+++ b/groups/cvo/netapp.tf
@@ -102,5 +102,5 @@ resource "aws_security_group_rule" "cardiff_nfs_cifs" {
   from_port   = each.value.port
   to_port     = lookup(each.value, "to_port", each.value.port)
   protocol    = each.value.protocol
-  cidr_blocks = ["172.19.236.0/24"]
+  cidr_blocks = var.nfs_cifs_cidrs
 }

--- a/groups/cvo/profiles/heritage-live-eu-west-2/vars
+++ b/groups/cvo/profiles/heritage-live-eu-west-2/vars
@@ -41,6 +41,10 @@ client_ports = [
     { "protocol" = "tcp", "port" = 11104, "to_port" = 11105 },
 ]
 
+nfs_cifs_cidrs = [
+  "172.19.236.0/24"
+]
+
 nfs_cifs_ports = [
     { "protocol" = "tcp", "port" = 111 },
     { "protocol" = "udp", "port" = 111 },

--- a/groups/cvo/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/cvo/profiles/heritage-staging-eu-west-2/vars
@@ -40,3 +40,21 @@ client_ports = [
     { "protocol" = "tcp", "port" = 10670 },
     { "protocol" = "tcp", "port" = 11104, "to_port" = 11105 },
 ]
+
+nfs_cifs_cidrs = [
+  "172.16.0.0/16"
+]
+
+nfs_cifs_ports = [
+    { "protocol" = "tcp", "port" = 111 },
+    { "protocol" = "udp", "port" = 111 },
+    { "protocol" = "tcp", "port" = 2049 },
+    { "protocol" = "udp", "port" = 2049 },
+    { "protocol" = "tcp", "port" = 635 },
+    { "protocol" = "udp", "port" = 635 },
+    { "protocol" = "tcp", "port" = 4045, "to_port" = 4046 },
+    { "protocol" = "udp", "port" = 4045, "to_port" = 4046 },
+    { "protocol" = "udp", "port" = 137, "to_port" = 138 },
+    { "protocol" = "tcp", "port" = 139 },
+    { "protocol" = "tcp", "port" = 445 },
+]

--- a/groups/cvo/variables.tf
+++ b/groups/cvo/variables.tf
@@ -116,6 +116,12 @@ variable "client_ports" {
   default     = []
 }
 
+variable "nfs_cifs_cidrs" {
+  type        = list(any)
+  description = "A list of CIDRs to allow NFS/CIFS access from"
+  default     = []
+}
+
 variable "nfs_cifs_ports" {
   type        = list(any)
   description = "A list of ports to allow from on-premise ranges"


### PR DESCRIPTION
Added new var `nfs_cifs_cidrs` to define a list of backend CIDRs requiring NFS and CIFS access
Updated `cardiff_nfs_cifs` security group rule to use `nfs_cifs_cidrs` var
Updated live vars to specify list for `nfs_cifs_cidrs` to replicate existing rules
Added and populated `nfs_cifs_cidrs` and `nfs_cifs_ports` to staging vars