### PR TITLE
Adding a network interface lookup instead of instance because each NetApp EC2 instance has multiple ENI attached

### DIFF
--- a/groups/cvo/README.md
+++ b/groups/cvo/README.md
@@ -36,8 +36,8 @@
 | [aws_security_group_rule.onpremise](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.onpremise_admin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.onpremise_icmp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_instance.cvo_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/instance) | data source |
 | [aws_instances.cvo_instances](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/instances) | data source |
+| [aws_network_interfaces.netapp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/network_interfaces) | data source |
 | [aws_route53_zone.private_zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 | [aws_route_table.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route_table) | data source |
 | [aws_subnet_ids.storage](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |

--- a/groups/cvo/data.tf
+++ b/groups/cvo/data.tf
@@ -62,9 +62,11 @@ data "aws_instances" "cvo_instances" {
   ]
 }
 
-data "aws_instance" "cvo_instance" {
+data "aws_network_interfaces" "netapp" {
   for_each = toset(data.aws_instances.cvo_instances.ids)
 
-  instance_id = each.value
-
+  filter {
+    name   = "attachment.instance-id"
+    values = [each.value]
+  }
 }

--- a/groups/cvo/locals.tf
+++ b/groups/cvo/locals.tf
@@ -38,6 +38,7 @@ locals {
   # Create a map of vpc cidrs => ports to use as security group rules
   ingress_cidrs = length(var.vpc_ingress_cidrs) >= 1 ? setproduct(var.vpc_ingress_cidrs, local.cvo_ingress_ports) : []
 
+  netapp_nics = flatten([for eni in data.aws_network_interfaces.netapp : eni.ids])
 
   default_tags = {
     Terraform = "true"

--- a/groups/cvo/security-groups.tf
+++ b/groups/cvo/security-groups.tf
@@ -12,10 +12,10 @@ module "netapp_secondary_security_group" {
 }
 
 resource "aws_network_interface_sg_attachment" "cvo_instance_sgr_attachment" {
-  for_each = data.aws_instance.cvo_instance
+  for_each = toset(local.netapp_nics)
 
   security_group_id    = module.netapp_secondary_security_group.this_security_group_id
-  network_interface_id = each.value.network_interface_id
+  network_interface_id = each.value
 
 }
 


### PR DESCRIPTION
Adding a network interface lookup instead of instance because each NetApp EC2 instance has multiple ENI attached