### PR TITLE
Removing instance Ids lookup, doing a direct network interface lookup

### DIFF
--- a/groups/cvo/README.md
+++ b/groups/cvo/README.md
@@ -36,7 +36,6 @@
 | [aws_security_group_rule.onpremise](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.onpremise_admin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.onpremise_icmp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_instances.cvo_instances](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/instances) | data source |
 | [aws_network_interfaces.netapp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/network_interfaces) | data source |
 | [aws_route53_zone.private_zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 | [aws_route_table.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route_table) | data source |
@@ -80,5 +79,7 @@
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_nics"></a> [nics](#output\_nics) | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/groups/cvo/data.tf
+++ b/groups/cvo/data.tf
@@ -45,28 +45,19 @@ data "vault_generic_secret" "netapp_cvo" {
   path = "applications/${var.aws_account}-${var.aws_region}/netapp/cvo-inputs"
 }
 
-data "aws_instances" "cvo_instances" {
-  instance_tags = {
-    WorkingEnvironment = "cvonetapp${var.account}001"
+data "aws_network_interfaces" "netapp" {
+
+  tags = {
+    "aws:cloudformation:stack-name" = "cvonetapp${var.account}001"
   }
 
   filter {
-    name   = "image-id"
-    values = [var.cvo_instance_ami_id]
+    name   = "subnet-id"
+    values = data.aws_subnet_ids.storage.ids
   }
 
-  instance_state_names = ["running"]
-
-  depends_on = [
-    module.cvo
-  ]
 }
 
-data "aws_network_interfaces" "netapp" {
-  for_each = toset(data.aws_instances.cvo_instances.ids)
-
-  filter {
-    name   = "attachment.instance-id"
-    values = [each.value]
-  }
+output "nics" {
+  value = data.aws_network_interfaces.netapp.ids
 }

--- a/groups/cvo/locals.tf
+++ b/groups/cvo/locals.tf
@@ -38,8 +38,6 @@ locals {
   # Create a map of vpc cidrs => ports to use as security group rules
   ingress_cidrs = length(var.vpc_ingress_cidrs) >= 1 ? setproduct(var.vpc_ingress_cidrs, local.cvo_ingress_ports) : []
 
-  netapp_nics = flatten([for eni in data.aws_network_interfaces.netapp : eni.ids])
-
   default_tags = {
     Terraform = "true"
     Project   = "Storage"

--- a/groups/cvo/security_groups.tf
+++ b/groups/cvo/security_groups.tf
@@ -9,14 +9,25 @@ module "netapp_secondary_security_group" {
   description = "Secondary security group for the NetApp CVO Service"
   vpc_id      = data.aws_vpc.vpc.id
 
+  tags = merge(
+    local.default_tags,
+    map(
+      "Name", "sgr-netapp-${var.account}-002",
+      "ServiceTeam", "Storage"
+    )
+  )
 }
 
 resource "aws_network_interface_sg_attachment" "cvo_instance_sgr_attachment" {
-  for_each = toset(local.netapp_nics)
+  for_each = toset(data.aws_network_interfaces.netapp.ids)
 
   security_group_id    = module.netapp_secondary_security_group.this_security_group_id
   network_interface_id = each.value
 
+  depends_on = [
+    module.netapp_secondary_security_group,
+    data.aws_network_interfaces.netapp
+  ]
 }
 
 resource "aws_security_group_rule" "ingress_cidrs" {


### PR DESCRIPTION
Removing instance Ids lookup, doing a direct network interface lookup due to bug in Terraform for_each dependencies, this now looks for all nics in the storage subnets that have a specific tag. That tag is only used on storage nodes