### PR TITLE
Update on-prem Access CIDRs for NFS/CIFS

### DIFF
--- a/groups/cvo/profiles/heritage-live-eu-west-2/vars
+++ b/groups/cvo/profiles/heritage-live-eu-west-2/vars
@@ -48,8 +48,7 @@ client_ports = [
 ]
 
 nfs_cifs_cidrs = [
-  "172.19.236.0/24",
-  "172.16.0.0/16"
+  "172.16.0.0/12"
 ]
 
 nfs_cifs_ports = [


### PR DESCRIPTION
Updated `nfs_cifs_cidrs` for on-prem access