### PR TITLE
Unified Manager - Allow Syslog Ingress

### DIFF
--- a/groups/unifiedmanager/ec2.tf
+++ b/groups/unifiedmanager/ec2.tf
@@ -16,6 +16,13 @@ module "unified_manager_ec2_security_group" {
     {
       from_port   = 514
       to_port     = 514
+      protocol    = "tcp"
+      description = "Syslog Collector"
+      cidr_blocks = join(",", local.admin_cidrs)
+    },
+    {
+      from_port   = 514
+      to_port     = 514
       protocol    = "udp"
       description = "Syslog Collector"
       cidr_blocks = join(",", local.admin_cidrs)

--- a/groups/unifiedmanager/ec2.tf
+++ b/groups/unifiedmanager/ec2.tf
@@ -12,6 +12,15 @@ module "unified_manager_ec2_security_group" {
 
   ingress_cidr_blocks = local.admin_cidrs
   ingress_rules       = ["http-80-tcp", "https-443-tcp", "ssh-tcp"]
+  ingress_with_cidr_blocks = [
+    {
+      from_port   = 514
+      to_port     = 514
+      protocol    = "udp"
+      description = "Syslog Collector"
+      cidr_blocks = join(",", local.admin_cidrs)
+    }
+  ]
   egress_rules        = ["all-all"]
 }
 

--- a/groups/unifiedmanager/profiles/shared-services-eu-west-2/vars
+++ b/groups/unifiedmanager/profiles/shared-services-eu-west-2/vars
@@ -8,6 +8,9 @@ region  = "euw2"
 # Application
 application = "unified-manager"
 
+# AMI Version
+ami_name = "centos7-base-0.1.7"
+
 # NetApp Unified Manager
 unified_manager_instance_type = "t3.xlarge"
 unified_manager_company_name = "companieshouse"


### PR DESCRIPTION
Updated security group to allow syslog
Fixed AMI version for unified manager instance as it cannot be gracefully replaced in an automated fashion.

Resolves: INC0353920
