### PR TITLE
Revert cvo Group & Update tooling Rules

### DIFF
--- a/groups/cvo/data.tf
+++ b/groups/cvo/data.tf
@@ -61,27 +61,6 @@ data "aws_network_interfaces" "netapp" {
   ]
 }
 
-data "aws_network_interfaces" "netapp2" {
-  count  = var.enable_cvo2_deployment ? 1 : 0
-
-  tags = {
-    "aws:cloudformation:stack-name" = "cvonetappnew${var.account}001"
-  }
-
-  filter {
-    name   = "subnet-id"
-    values = data.aws_subnet_ids.storage.ids
-  }
-
-  depends_on = [
-    module.cvo2
-  ]
-
-}
-
 output "nics" {
   value = data.aws_network_interfaces.netapp.ids
-}
-output "nics2" {
-  value = data.aws_network_interfaces.netapp2[0].ids
 }

--- a/groups/cvo/locals.tf
+++ b/groups/cvo/locals.tf
@@ -10,9 +10,6 @@ locals {
 
   internal_fqdn = format("%s.%s.aws.internal", split("-", var.aws_account)[1], split("-", var.aws_account)[0])
 
-  cvo2_netapp_interface_ids = var.enable_cvo2_deployment ? data.aws_network_interfaces.netapp2[0].ids : []
-  cvo2_data_interface_ids   = var.enable_cvo2_deployment ? data.aws_network_interfaces.cvo2_data_eni[0].ids : []
-
   # See https://docs.netapp.com/us-en/occm/reference_security_groups.html#rules-for-cloud-volumes-ontap for port details
   # Initially leaving egress open as per netapp reccomendations, we can restrict this further after initial deploys if required.
   cvo_ingress_ports = [

--- a/groups/cvo/locals.tf
+++ b/groups/cvo/locals.tf
@@ -38,6 +38,13 @@ locals {
   # Create a map of vpc cidrs => ports to use as security group rules
   ingress_cidrs = length(var.vpc_ingress_cidrs) >= 1 ? setproduct(var.vpc_ingress_cidrs, local.cvo_ingress_ports) : []
 
+  tooling_cidrs = {
+    connector      = var.netapp_connector_ip,
+    unifiedmanager = var.netapp_unifiedmanager_ip,
+    insight        = var.netapp_insight_ip,
+    snapcenter     = var.netapp_snapcenter_ip
+  }
+
   default_tags = {
     Terraform = "true"
     Project   = "Storage"

--- a/groups/cvo/main.tf
+++ b/groups/cvo/main.tf
@@ -15,7 +15,7 @@ terraform {
     }
     netapp-cloudmanager = {
       source  = "NetApp/netapp-cloudmanager"
-      version = "23.7.0"
+      version = "20.12.0"
     }
   }
   backend "s3" {}

--- a/groups/cvo/netapp.tf
+++ b/groups/cvo/netapp.tf
@@ -25,48 +25,7 @@ module "cvo" {
   connector_accountId     = local.account_ids["shared-services"]
   svm_password            = local.netapp_cvo_data["svm-password"]
   cloud_provider_account  = var.connector_account_access_id
-  ebs_volume_type         = var.ebs_volume_type_cvo
-
-  ## Security Group setting
-  ingress_cidr_blocks = [
-    data.aws_vpc.vpc.cidr_block
-  ]
-
-  route_table_ids = [data.aws_route_table.private.route_table_id]
-
-  tags = merge(
-    local.default_tags,
-    map(
-      "ServiceTeam", "Storage"
-    )
-  )
-}
-
-module "cvo2" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/netapp_cloudmanager_cvo_aws?ref=tags/1.0.189"
-  count  = var.enable_cvo2_deployment ? 1 : 0
-
-  vpc_id     = data.aws_vpc.vpc.id
-  subnet_ids = data.aws_subnet_ids.storage.ids
-
-  ## cvo setup
-  name                    = format("%s-%s-%s", var.cvo2_name, var.account, "001")
-  short_name              = var.cvo2_name
-  instance_type           = var.cvo_instance_type
-  ebs_volume_size         = var.cvo_ebs_volume_size
-  ebs_volume_size_unit    = var.cvo_ebs_volume_size_unit
-  license_type            = var.cvo_license_type
-  is_ha                   = var.cvo_is_ha
-  use_latest_version      = true
-  platform_serial_numbers = try(jsondecode(local.netapp_cvo_data["node-serial-numbers"]), [null, null])
-  cluster_floating_ips    = var.cvo_floating_ips
-  mediator_key_pair_name  = aws_key_pair.netapp_mediator_key.key_name
-  connector_client_id     = local.netapp_connector_data["connector-client-id"]
-  connector_accountId     = local.account_ids["shared-services"]
-  svm_password            = local.netapp_cvo_data["svm-password"]
-  cloud_provider_account  = var.connector_account_access_id
-  capacity_tier           = var.capacity_tier 
-  ebs_volume_type         = var.ebs_volume_type_cvo2
+  ebs_volume_type         = var.ebs_volume_type
 
   ## Security Group setting
   ingress_cidr_blocks = [

--- a/groups/cvo/profiles/heritage-development-eu-west-2/vars
+++ b/groups/cvo/profiles/heritage-development-eu-west-2/vars
@@ -7,15 +7,12 @@ region  = "euw2"
 
 # NetApp Cloud Volumes Ontap (CVO)
 cvo_name                    = "netapp"
-cvo2_name                   = "netapp-new"
 cvo_instance_type           = "m5.xlarge"
 cvo_license_type            = "cot-explore-paygo"
 cvo_is_ha                   = false
 cvo_ontap_version           = "ONTAP-9.7P5.T1"
 connector_account_access_id = "CloudProviderAccount-jufYYNpi"
 cvo_instance_ami_id         = "ami-0522b8ca8e272d9c1"
-
-enable_cvo2_deployment = true
 
 client_ips = [
 "10.10.9.0/28",

--- a/groups/cvo/profiles/heritage-live-eu-west-2/vars
+++ b/groups/cvo/profiles/heritage-live-eu-west-2/vars
@@ -7,7 +7,6 @@ region  = "euw2"
 
 # NetApp Cloud Volumes Ontap (CVO)
 cvo_name                    = "netapp"
-cvo2_name                   = "netapp-new"
 cvo_instance_type           = "m5.4xlarge"
 cvo_license_type            = "ha-cot-premium-byol"
 cvo_is_ha                   = true

--- a/groups/cvo/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/cvo/profiles/heritage-staging-eu-west-2/vars
@@ -7,7 +7,6 @@ region  = "euw2"
 
 # NetApp Cloud Volumes Ontap (CVO)
 cvo_name                    = "netapp"
-cvo2_name                   = "netapp-new"
 cvo_instance_type           = "m5.4xlarge"
 cvo_license_type            = "ha-cot-premium-paygo"
 cvo_is_ha                   = true

--- a/groups/cvo/security_group_rules.tf
+++ b/groups/cvo/security_group_rules.tf
@@ -13,23 +13,6 @@ resource "aws_security_group_rule" "netapp_tooling" {
     var.netapp_snapcenter_ip
   ]
 }
-
-resource "aws_security_group_rule" "netapp_tooling_new" {
-  security_group_id = module.cvo2[0].cvo_security_group_id
-  description       = "Rules for NetApp Tools - Connector, Unified Manager and SnapCenter"
-
-  type      = "ingress"
-  from_port = "-1"
-  to_port   = "-1"
-  protocol  = "-1"
-  cidr_blocks = [
-    var.netapp_connector_ip,
-    var.netapp_unifiedmanager_ip,
-    var.netapp_insight_ip,
-    var.netapp_snapcenter_ip
-  ]
-}
-
 resource "aws_security_group_rule" "onpremise" {
   for_each = { for rule in var.client_ports : rule.port => rule }
 
@@ -67,18 +50,6 @@ resource "aws_security_group_rule" "onpremise_admin" {
   cidr_blocks       = local.admin_cidrs
 }
 
-resource "aws_security_group_rule" "onpremise_admin2" {
-
-  security_group_id = module.cvo2[0].cvo_security_group_id
-  description       = "Allow on-premise ranges to access CVO over SSH and HTTPS for administration"
-  for_each          = toset(["22", "443"])
-  type              = "ingress"
-  from_port         = each.value
-  to_port           = each.value
-  protocol          = "tcp"
-  cidr_blocks       = local.admin_cidrs
-}
-
 resource "aws_security_group_rule" "cardiff_nfs_cifs" {
   for_each = { for rule in var.nfs_cifs_ports : join("_", [rule.protocol, rule.port]) => rule }
 
@@ -98,14 +69,6 @@ data "aws_network_interfaces" "cvo_data_eni" {
   filter {
     name   = "group-id"
     values = [module.cvo.cvo_security_group_id]
-  }
-}
-
-data "aws_network_interfaces" "cvo2_data_eni" {
-  count  = var.enable_cvo2_deployment ? 1 : 0
-  filter {
-    name   = "group-id"
-    values = [module.cvo2[0].cvo_security_group_id]
   }
 }
 

--- a/groups/cvo/security_group_rules.tf
+++ b/groups/cvo/security_group_rules.tf
@@ -1,18 +1,16 @@
 resource "aws_security_group_rule" "netapp_tooling" {
-  security_group_id = module.cvo.cvo_security_group_id
-  description       = "Rules for NetApp Tools - Connector, Unified Manager and SnapCenter"
+  for_each = local.tooling_cidrs
 
-  type      = "ingress"
-  from_port = "-1"
-  to_port   = "-1"
-  protocol  = "-1"
-  cidr_blocks = [
-    var.netapp_connector_ip,
-    var.netapp_unifiedmanager_ip,
-    var.netapp_insight_ip,
-    var.netapp_snapcenter_ip
-  ]
+  security_group_id = module.cvo.cvo_security_group_id
+  description       = "Tooling access from ${each.key}"
+
+  type              = "ingress"
+  from_port         = "-1"
+  to_port           = "-1"
+  protocol          = "-1"
+  cidr_blocks       = [each.value]
 }
+
 resource "aws_security_group_rule" "onpremise" {
   for_each = { for rule in var.client_ports : rule.port => rule }
 

--- a/groups/cvo/security_groups.tf
+++ b/groups/cvo/security_groups.tf
@@ -27,18 +27,6 @@ resource "aws_network_interface_sg_attachment" "cvo_instance_sgr_attachment" {
   ]
 }
 
-resource "aws_network_interface_sg_attachment" "cvo2_instance_sgr_attachment" {
-  for_each = toset(local.cvo2_netapp_interface_ids)
-
-  security_group_id    = module.netapp_secondary_security_group.this_security_group_id
-  network_interface_id = each.value
-
-  depends_on = [
-    module.netapp_secondary_security_group,
-    data.aws_network_interfaces.netapp2
-  ]
-}
-
 resource "aws_security_group_rule" "ingress_cidrs" {
   count = length(local.ingress_cidrs)
 
@@ -75,40 +63,11 @@ resource "aws_security_group" "cvo_data_nfs_sg" {
   )
 }
 
-resource "aws_security_group" "cvo2_data_nfs_sg" {
-  count  = var.enable_cvo2_deployment ? 1 : 0
-  name        = "sgr-netapp-${var.account}-nfs-002"
-  description = "Allow client access to NFS services"
-  vpc_id      = data.aws_vpc.vpc.id
-
-  egress {
-    from_port        = 0
-    to_port          = 0
-    protocol         = "-1"
-    cidr_blocks      = ["0.0.0.0/0"]
-  }
-
-  tags = merge(
-    local.default_tags,
-    map(
-      "Name", "sgr-netapp-${var.account}-nfs-002",
-      "ServiceTeam", "Storage"
-    )
-  )
-}
-
 resource "aws_network_interface_sg_attachment" "cvo_data_nfs_sg_attachment" {
   count = length(data.aws_network_interfaces.cvo_data_eni.ids)
 
   security_group_id    = aws_security_group.cvo_data_nfs_sg.id
   network_interface_id = sort(data.aws_network_interfaces.cvo_data_eni.ids)[count.index]
-}
-
-resource "aws_network_interface_sg_attachment" "cvo2_data_nfs_sg_attachment" {
- count = length(local.cvo2_data_interface_ids)
-
- security_group_id    = aws_security_group.cvo2_data_nfs_sg[0].id
- network_interface_id = sort(local.cvo2_data_interface_ids)[count.index]
 }
 
 
@@ -137,38 +96,9 @@ resource "aws_security_group" "cvo_data_cifs_sg" {
   )
 }
 
-resource "aws_security_group" "cvo2_data_cifs_sg" {
-  count  = var.enable_cvo2_deployment ? 1 : 0
-  name        = "sgr-netapp-${var.account}-cifs-002"
-  description = "Allow client access to CIFS services"
-  vpc_id      = data.aws_vpc.vpc.id
-
-  egress {
-    from_port        = 0
-    to_port          = 0
-    protocol         = "-1"
-    cidr_blocks      = ["0.0.0.0/0"]
-  }
-
-  tags = merge(
-    local.default_tags,
-    map(
-      "Name", "sgr-netapp-${var.account}-cifs-002",
-      "ServiceTeam", "Storage"
-    )
-  )
-}
-
 resource "aws_network_interface_sg_attachment" "cvo_data_cifs_sg_attachment" {
   count = length(data.aws_network_interfaces.cvo_data_eni.ids)
 
   security_group_id    = aws_security_group.cvo_data_cifs_sg.id
   network_interface_id = sort(data.aws_network_interfaces.cvo_data_eni.ids)[count.index]
-}
-
-resource "aws_network_interface_sg_attachment" "cvo2_data_cifs_sg_attachment" {
- count = length(local.cvo2_data_interface_ids)
-
- security_group_id    = aws_security_group.cvo2_data_cifs_sg[0].id
- network_interface_id = sort(local.cvo2_data_interface_ids)[count.index]
 }

--- a/groups/cvo/variables.tf
+++ b/groups/cvo/variables.tf
@@ -39,11 +39,6 @@ variable "cvo_name" {
   description = "Name for the resources table being created"
 }
 
-variable "cvo2_name" {
-  type        = string
-  description = "Name for the resources table being created for the upgrade"
-}
-
 variable "cvo_instance_ami_id" {
   type        = string
   description = "An AMI Id thats used by the CVO instances, used for lookups of instance Ids to assign security groups to."
@@ -80,13 +75,6 @@ variable "cvo_ontap_version" {
   type        = string
   description = "The required ONTAP version. Ignored if 'use_latest_version' is set to true. The default is to use the latest version."
 }
-
-variable "enable_cvo2_deployment" {
-  type        = bool
-  description = "This enables and disables the deployment of the new CVO module"
-  default     = false
-}
-
 variable "cvo_floating_ips" {
   type        = list(string)
   default     = [null, null, null, null]
@@ -206,14 +194,8 @@ variable "capacity_tier" {
   description = "(Optional) Whether to enable data tiering for the first data aggregate: ['S3','NONE']. The default is 'NONE'."
 }
 
-variable "ebs_volume_type_cvo" {
+variable "ebs_volume_type" {
   type        = string
   default     = "gp2"
-  description = "(Optional) The EBS volume type for the first data aggregate ['gp2','io1','st1','sc1']. The default is 'gp3'."
-}
-
-variable "ebs_volume_type_cvo2" {
-  type        = string
-  default     = "gp3"
-  description = "(Optional) The EBS volume type for the first data aggregate ['gp2','io1','st1','sc1']. The default is 'gp3'."
+  description = "(Optional) The EBS volume type for the first data aggregate ['gp3','gp2','io1','st1','sc1']. The default is 'gp3'."
 }


### PR DESCRIPTION
Merged in updates to revert `cvo` group.
Updated "tooling" security group rules to use a `for_each` instead of a list of CIDRs - this means each rule is properly indexed and the config is less brittle
Added supporting local