### PR TITLE
iops and throughput variables required for gp3

### DIFF
--- a/groups/cvo2/netapp.tf
+++ b/groups/cvo2/netapp.tf
@@ -26,6 +26,8 @@ module "cvo2" {
   cloud_provider_account  = var.connector_account_access_id
   capacity_tier           = var.capacity_tier 
   ebs_volume_type         = var.ebs_volume_type
+  iops                    = var.iops
+  throughput              = var.throughput
 
   ## Security Group setting
   ingress_cidr_blocks = [

--- a/groups/cvo2/variables.tf
+++ b/groups/cvo2/variables.tf
@@ -195,3 +195,15 @@ variable "ebs_volume_type" {
   default     = "gp3"
   description = "(Optional) The EBS volume type for the first data aggregate ['gp3','gp2','io1','st1','sc1']. The default is 'gp3'."
 }
+
+variable "iops" {
+  type        = number
+  default     = 3000
+  description = "the provisioned Iops value for the gp3 volume types"
+}
+
+variable "throughput" {
+  type        = number 
+  default     = 125
+  description = "The throughput value for the gp3 volume types"
+}


### PR DESCRIPTION
Iops and throughput parameters required due to gp3 volume types being chosen