### PR TITLE
feature/DVOP-2597

### DIFF
--- a/groups/cvo/profiles/heritage-development-eu-west-2/vars
+++ b/groups/cvo/profiles/heritage-development-eu-west-2/vars
@@ -35,3 +35,7 @@ client_ports = [
     { "protocol" = "tcp", "port" = 10670 },
     { "protocol" = "tcp", "port" = 11104, "to_port" = 11105 },
 ]
+
+peering_cidrs = [
+  "172.16.201.15/32"
+]

--- a/groups/cvo/profiles/heritage-live-eu-west-2/vars
+++ b/groups/cvo/profiles/heritage-live-eu-west-2/vars
@@ -73,3 +73,7 @@ nfs_client_cidrs = [
 cifs_client_cidrs = [
     "172.16.0.0/12"
 ]
+
+peering_cidrs = [
+  "172.16.201.15/32"
+]

--- a/groups/cvo/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/cvo/profiles/heritage-staging-eu-west-2/vars
@@ -71,3 +71,7 @@ nfs_client_cidrs = [
 cifs_client_cidrs = [
     "172.16.0.0/12"
 ]
+
+peering_cidrs = [
+  "172.16.201.15/32"
+]

--- a/groups/cvo/security_group_rules.tf
+++ b/groups/cvo/security_group_rules.tf
@@ -17,11 +17,11 @@ resource "aws_security_group_rule" "onpremise" {
   security_group_id = module.cvo.cvo_security_group_id
   description       = "Allow on premise ranges to access CVO"
 
-  type        = "ingress"
-  from_port   = each.value.port
-  to_port     = lookup(each.value, "to_port", each.value.port)
-  protocol    = each.value.protocol
-  cidr_blocks = var.client_ips
+  type              = "ingress"
+  from_port         = each.value.port
+  to_port           = lookup(each.value, "to_port", each.value.port)
+  protocol          = each.value.protocol
+  cidr_blocks       = var.client_ips
 }
 
 resource "aws_security_group_rule" "onpremise_icmp" {
@@ -29,11 +29,11 @@ resource "aws_security_group_rule" "onpremise_icmp" {
   security_group_id = module.cvo.cvo_security_group_id
   description       = "Allow only the on premise NetApp metro-cluster range to ping CVO via ICMP"
 
-  type        = "ingress"
-  from_port   = "-1"
-  to_port     = "-1"
-  protocol    = "icmp"
-  cidr_blocks = var.client_ips_icmp
+  type              = "ingress"
+  from_port         = "-1"
+  to_port           = "-1"
+  protocol          = "icmp"
+  cidr_blocks       = var.client_ips_icmp
 }
 
 resource "aws_security_group_rule" "onpremise_admin" {
@@ -54,11 +54,11 @@ resource "aws_security_group_rule" "cardiff_nfs_cifs" {
   security_group_id = module.cvo.cvo_security_group_id
   description       = "Allow Cardiff Backend range to access CVO via NFS and CIFS"
 
-  type        = "ingress"
-  from_port   = each.value.port
-  to_port     = lookup(each.value, "to_port", each.value.port)
-  protocol    = each.value.protocol
-  cidr_blocks = var.nfs_cifs_cidrs
+  type              = "ingress"
+  from_port         = each.value.port
+  to_port           = lookup(each.value, "to_port", each.value.port)
+  protocol          = each.value.protocol
+  cidr_blocks       = var.nfs_cifs_cidrs
 }
 
 # ------------------------------------------------------------------------------
@@ -80,11 +80,11 @@ resource "aws_security_group_rule" "cvo_data_nfs" {
   security_group_id = aws_security_group.cvo_data_nfs_sg.id
   description       = "Allow clients to access CVO via NFS"
 
-  type        = "ingress"
-  from_port   = each.value.port
-  to_port     = lookup(each.value, "to_port", each.value.port)
-  protocol    = each.value.protocol
-  cidr_blocks = var.nfs_client_cidrs
+  type              = "ingress"
+  from_port         = each.value.port
+  to_port           = lookup(each.value, "to_port", each.value.port)
+  protocol          = each.value.protocol
+  cidr_blocks       = var.nfs_client_cidrs
 }
 
 
@@ -97,11 +97,11 @@ resource "aws_security_group_rule" "cvo_data_cifs" {
   security_group_id = aws_security_group.cvo_data_cifs_sg.id
   description       = "Allow clients to access CVO via CIFS"
 
-  type        = "ingress"
-  from_port   = each.value.port
-  to_port     = lookup(each.value, "to_port", each.value.port)
-  protocol    = each.value.protocol
-  cidr_blocks = local.cifs_client_cidrs
+  type              = "ingress"
+  from_port         = each.value.port
+  to_port           = lookup(each.value, "to_port", each.value.port)
+  protocol          = each.value.protocol
+  cidr_blocks       = local.cifs_client_cidrs
 }
 
 # ------------------------------------------------------------------------------
@@ -111,37 +111,37 @@ resource "aws_security_group_rule" "onprem_peering_10000" {
   for_each = { for idx, cidr in var.peering_cidrs : idx => cidr }
 
   security_group_id = module.cvo.cvo_security_group_id
-  description = "Enable cluster peering from ${each.value}"
+  description       = "Enable cluster peering from ${each.value}"
 
-  type        = "ingress"
-  from_port   = 10000
-  to_port     = 10000
-  protocol    = "tcp"
-  cidr_blocks = [each.value]
+  type              = "ingress"
+  from_port         = 10000
+  to_port           = 10000
+  protocol          = "tcp"
+  cidr_blocks       = [each.value]
 }
 
 resource "aws_security_group_rule" "onprem_peering_11104" {
   for_each = { for idx, cidr in var.peering_cidrs : idx => cidr }
   
   security_group_id = module.cvo.cvo_security_group_id
-  description = "Enable cluster peering from ${each.value}"
+  description       = "Enable cluster peering from ${each.value}"
 
-  type        = "ingress"
-  from_port   = 11104
-  to_port     = 11105
-  protocol    = "tcp"
-  cidr_blocks = [each.value]
+  type              = "ingress"
+  from_port         = 11104
+  to_port           = 11105
+  protocol          = "tcp"
+  cidr_blocks       = [each.value]
 }
 
 resource "aws_security_group_rule" "onprem_peering_icmp" {
   for_each = { for idx, cidr in var.peering_cidrs : idx => cidr }
 
   security_group_id = module.cvo.cvo_security_group_id
-  description = "Enable cluster peering from ${each.value}"
+  description       = "Enable cluster peering from ${each.value}"
 
-  type        = "ingress"
-  from_port   = -1
-  to_port     = -1
-  protocol    = "icmp"
-  cidr_blocks = [each.value]
+  type              = "ingress"
+  from_port         = -1
+  to_port           = -1
+  protocol          = "icmp"
+  cidr_blocks       = [each.value]
 }

--- a/groups/cvo/security_group_rules.tf
+++ b/groups/cvo/security_group_rules.tf
@@ -103,3 +103,45 @@ resource "aws_security_group_rule" "cvo_data_cifs" {
   protocol    = each.value.protocol
   cidr_blocks = local.cifs_client_cidrs
 }
+
+# ------------------------------------------------------------------------------
+# Dedicated Cluster Peering
+# ------------------------------------------------------------------------------
+resource "aws_security_group_rule" "onprem_peering_10000" {
+  for_each = { for idx, cidr in var.peering_cidrs : idx => cidr }
+
+  security_group_id = module.cvo.cvo_security_group_id
+  description = "Enable cluster peering from ${each.value}"
+
+  type        = "ingress"
+  from_port   = 10000
+  to_port     = 10000
+  protocol    = "tcp"
+  cidr_blocks = [each.value]
+}
+
+resource "aws_security_group_rule" "onprem_peering_11104" {
+  for_each = { for idx, cidr in var.peering_cidrs : idx => cidr }
+  
+  security_group_id = module.cvo.cvo_security_group_id
+  description = "Enable cluster peering from ${each.value}"
+
+  type        = "ingress"
+  from_port   = 11104
+  to_port     = 11105
+  protocol    = "tcp"
+  cidr_blocks = [each.value]
+}
+
+resource "aws_security_group_rule" "onprem_peering_icmp" {
+  for_each = { for idx, cidr in var.peering_cidrs : idx => cidr }
+
+  security_group_id = module.cvo.cvo_security_group_id
+  description = "Enable cluster peering from ${each.value}"
+
+  type        = "ingress"
+  from_port   = -1
+  to_port     = -1
+  protocol    = "icmp"
+  cidr_blocks = [each.value]
+}

--- a/groups/cvo/variables.tf
+++ b/groups/cvo/variables.tf
@@ -194,6 +194,11 @@ variable "cifs_client_cidrs" {
   default     = []
 }
 
+variable "peering_cidrs" { 
+  type        = list(any) 
+  description = "The full CIDR formatted IPs used for cluster peering from Cardiff nodes to all AWS CVO instances " 
+}
+
 variable "capacity_tier" {
   type        = string
   default     = "NONE"

--- a/groups/cvo/variables.tf
+++ b/groups/cvo/variables.tf
@@ -195,8 +195,8 @@ variable "cifs_client_cidrs" {
 }
 
 variable "peering_cidrs" { 
-  type        = list(any) 
-  description = "The full CIDR formatted IP used for cluster peering from Cardiff nodes to all AWS CVO instances " 
+  type        = list(string) 
+  description = "A List of CIDRs used for cluster peering" 
 }
 
 variable "capacity_tier" {

--- a/groups/cvo/variables.tf
+++ b/groups/cvo/variables.tf
@@ -196,7 +196,7 @@ variable "cifs_client_cidrs" {
 
 variable "peering_cidrs" { 
   type        = list(any) 
-  description = "The full CIDR formatted IPs used for cluster peering from Cardiff nodes to all AWS CVO instances " 
+  description = "The full CIDR formatted IP used for cluster peering from Cardiff nodes to all AWS CVO instances " 
 }
 
 variable "capacity_tier" {


### PR DESCRIPTION
Implementing the ability for cluster peering from Cardiff nodes to all AWS CVO instances.

Request raised via: [INC0336527](https://companieshouse.service-now.com/now/nav/ui/classic/params/target/incident.do%3Fsys_id%3Dc2e3125a1b4e05106e645525464bcbdd%26sysparm_record_target%3Dincident%26sysparm_record_row%3D1%26sysparm_record_rows%3D5%26sysparm_record_list%3Dactive%253Dtrue%255Eassigned_to%253Djavascript%253AgetMyAssignments%2528%2529%255Estate%2521%253D6%255EORDERBYsys_created_on)

TF Runner Plan Identifies that only the 3 new resources are required to be added. nothing to change or remove


