### PR TITLE
Rework unifiedmanager group for Terraform 1.3

### DIFF
--- a/groups/unifiedmanager/README.md
+++ b/groups/unifiedmanager/README.md
@@ -3,25 +3,25 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0, < 0.14 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 0.3, < 4.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 1.4 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0, < 6.0 |
 | <a name="requirement_vault"></a> [vault](#requirement\_vault) | >= 2.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 0.3, < 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0, < 6.0 |
 | <a name="provider_vault"></a> [vault](#provider\_vault) | >= 2.0.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aiqum_backup_bucket"></a> [aiqum\_backup\_bucket](#module\_aiqum\_backup\_bucket) | terraform-aws-modules/s3-bucket/aws | 3.0.1 |
+| <a name="module_aiqum_backup_bucket"></a> [aiqum\_backup\_bucket](#module\_aiqum\_backup\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 4.7.0 |
 | <a name="module_s3_access_logging_aiqum"></a> [s3\_access\_logging\_aiqum](#module\_s3\_access\_logging\_aiqum) | git@github.com:companieshouse/terraform-modules//aws/s3_access_logging | tags/1.0.264 |
-| <a name="module_unified_manager_ec2_security_group"></a> [unified\_manager\_ec2\_security\_group](#module\_unified\_manager\_ec2\_security\_group) | terraform-aws-modules/security-group/aws | ~> 3.0 |
-| <a name="module_unified_manager_profile"></a> [unified\_manager\_profile](#module\_unified\_manager\_profile) | git@github.com:companieshouse/terraform-modules//aws/instance_profile | tags/1.0.40 |
+| <a name="module_unified_manager_ec2_security_group"></a> [unified\_manager\_ec2\_security\_group](#module\_unified\_manager\_ec2\_security\_group) | terraform-aws-modules/security-group/aws | ~> 5.3 |
+| <a name="module_unified_manager_profile"></a> [unified\_manager\_profile](#module\_unified\_manager\_profile) | git@github.com:companieshouse/terraform-modules//aws/instance_profile | tags/1.0.317 |
 
 ## Resources
 
@@ -31,9 +31,10 @@
 | [aws_key_pair.ec2_keypair](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) | resource |
 | [aws_route53_record.netapp_unified_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_ami.unified_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_ec2_managed_prefix_list.admin_cidr_ranges](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ec2_managed_prefix_list) | data source |
 | [aws_kms_key.ebs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
 | [aws_route53_zone.private_zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
-| [aws_subnet_ids.monitor](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
+| [aws_subnet.monitor_b](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 | [aws_vpc.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 | [vault_generic_secret.account_ids](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/data-sources/generic_secret) | data source |
 | [vault_generic_secret.unified_manager](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/data-sources/generic_secret) | data source |
@@ -47,6 +48,7 @@
 | <a name="input_application"></a> [application](#input\_application) | Name for the application being deployed | `string` | n/a | yes |
 | <a name="input_aws_account"></a> [aws\_account](#input\_aws\_account) | The AWS account in which resources will be administered | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | The AWS region in which resources will be administered | `string` | n/a | yes |
+| <a name="input_delete_on_termination"></a> [delete\_on\_termination](#input\_delete\_on\_termination) | Whether the volume should be destroyed on instance termination. | `bool` | `false` | no |
 | <a name="input_region"></a> [region](#input\_region) | The shorthand for the AWS region | `string` | n/a | yes |
 | <a name="input_unified_manager_company_name"></a> [unified\_manager\_company\_name](#input\_unified\_manager\_company\_name) | Company name string to be passed to NetApp module for naming and setup of Unified Manager | `string` | n/a | yes |
 | <a name="input_unified_manager_instance_type"></a> [unified\_manager\_instance\_type](#input\_unified\_manager\_instance\_type) | instance type to be used for the NetApp Unified Manager EC2 instance | `string` | n/a | yes |

--- a/groups/unifiedmanager/README.md
+++ b/groups/unifiedmanager/README.md
@@ -36,7 +36,6 @@
 | [aws_subnet_ids.monitor](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
 | [aws_vpc.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 | [vault_generic_secret.account_ids](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/data-sources/generic_secret) | data source |
-| [vault_generic_secret.internal_cidrs](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/data-sources/generic_secret) | data source |
 | [vault_generic_secret.unified_manager](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/data-sources/generic_secret) | data source |
 
 ## Inputs

--- a/groups/unifiedmanager/data.tf
+++ b/groups/unifiedmanager/data.tf
@@ -24,10 +24,6 @@ data "vault_generic_secret" "account_ids" {
   path = "aws-accounts/account-ids"
 }
 
-data "vault_generic_secret" "internal_cidrs" {
-  path = "aws-accounts/network/internal_cidr_ranges"
-}
-
 data "vault_generic_secret" "unified_manager" {
   path = "applications/${var.aws_account}-${var.aws_region}/netapp/${var.application}"
 }

--- a/groups/unifiedmanager/data.tf
+++ b/groups/unifiedmanager/data.tf
@@ -4,11 +4,10 @@ data "aws_vpc" "vpc" {
   }
 }
 
-data "aws_subnet_ids" "monitor" {
-  vpc_id = data.aws_vpc.vpc.id
+data "aws_subnet" "monitor_b" {
   filter {
     name   = "tag:Name"
-    values = ["sub-monitor-*"]
+    values = ["sub-monitor-b"]
   }
 }
 
@@ -50,4 +49,8 @@ data "aws_ami" "unified_manager" {
       "available",
     ]
   }
+}
+
+data "aws_ec2_managed_prefix_list" "admin_cidr_ranges" {
+  name = "administration-cidr-ranges"
 }

--- a/groups/unifiedmanager/ec2.tf
+++ b/groups/unifiedmanager/ec2.tf
@@ -3,32 +3,23 @@
 # ------------------------------------------------------------------------------
 module "unified_manager_ec2_security_group" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "~> 3.0"
+  version = "~> 5.3"
 
   name        = "sgr-${var.application}-001"
   description = "Security group for the ${var.application} ec2"
   vpc_id      = data.aws_vpc.vpc.id
 
+  ingress_prefix_list_ids = [local.admin_prefix_list_id]
 
-  ingress_cidr_blocks = local.admin_cidrs
-  ingress_rules       = ["http-80-tcp", "https-443-tcp", "ssh-tcp"]
-  ingress_with_cidr_blocks = [
-    {
-      from_port   = 514
-      to_port     = 514
-      protocol    = "tcp"
-      description = "Syslog Collector"
-      cidr_blocks = join(",", local.admin_cidrs)
-    },
-    {
-      from_port   = 514
-      to_port     = 514
-      protocol    = "udp"
-      description = "Syslog Collector"
-      cidr_blocks = join(",", local.admin_cidrs)
-    }
+  ingress_rules = [
+    "http-80-tcp",
+    "https-443-tcp",
+    "ssh-tcp",
+    "wazuh-server-syslog-collector-tcp",
+    "wazuh-server-syslog-collector-udp"
   ]
-  egress_rules        = ["all-all"]
+
+  egress_rules = ["all-all"]
 }
 
 # ------------------------------------------------------------------------------
@@ -39,8 +30,8 @@ resource "aws_instance" "netapp_unified_manager" {
   associate_public_ip_address = false
   key_name                    = aws_key_pair.ec2_keypair.key_name
   instance_type               = var.unified_manager_instance_type
-  subnet_id                   = coalesce(data.aws_subnet_ids.monitor.ids...)
-  vpc_security_group_ids      = [module.unified_manager_ec2_security_group.this_security_group_id]
+  subnet_id                   = data.aws_subnet.monitor_b.id
+  vpc_security_group_ids      = [module.unified_manager_ec2_security_group.security_group_id]
   iam_instance_profile        = module.unified_manager_profile.aws_iam_instance_profile.name
   root_block_device {
     volume_size           = "120"
@@ -58,10 +49,10 @@ resource "aws_instance" "netapp_unified_manager" {
 
   tags = merge(
     local.default_tags,
-    map(
-      "Name", "${var.application}-001",
-      "ServiceTeam", "Storage"
-    )
+    tomap({
+      "Name" : "${var.application}-001",
+      "ServiceTeam" : "Storage"
+    })
   )
 }
 

--- a/groups/unifiedmanager/iam.tf
+++ b/groups/unifiedmanager/iam.tf
@@ -1,19 +1,19 @@
 module "unified_manager_profile" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/instance_profile?ref=tags/1.0.40"
+  source = "git@github.com:companieshouse/terraform-modules//aws/instance_profile?ref=tags/1.0.317"
 
   name         = "unified_manager_profile"
-  enable_SSM   = true
+  enable_ssm   = true
   kms_key_refs = ["alias/${var.account}/${var.region}/ebs"]
 
   custom_statements = [
     {
-      sid       = "aiqumAccess"
-      effect    = "Allow"
+      sid    = "aiqumAccess"
+      effect = "Allow"
       resources = [
         module.aiqum_backup_bucket.s3_bucket_arn,
         "${module.aiqum_backup_bucket.s3_bucket_arn}/*"
       ]
-      actions   = [
+      actions = [
         "s3:Get*",
         "s3:List*",
         "s3:Put*",

--- a/groups/unifiedmanager/locals.tf
+++ b/groups/unifiedmanager/locals.tf
@@ -3,7 +3,7 @@
 # ------------------------------------------------------------------------
 locals {
   account_ids          = data.vault_generic_secret.account_ids.data
-  admin_cidrs          = values(data.vault_generic_secret.internal_cidrs.data)
+  admin_prefix_list_id = data.aws_ec2_managed_prefix_list.admin_cidr_ranges.id
   unified_manager_data = data.vault_generic_secret.unified_manager.data
 
   internal_fqdn = "${replace(var.aws_account, "-", "")}.aws.internal"

--- a/groups/unifiedmanager/locals.tf
+++ b/groups/unifiedmanager/locals.tf
@@ -8,8 +8,6 @@ locals {
 
   internal_fqdn = "${replace(var.aws_account, "-", "")}.aws.internal"
 
-
-
   default_tags = {
     Terraform = "true"
     Project   = var.account

--- a/groups/unifiedmanager/main.tf
+++ b/groups/unifiedmanager/main.tf
@@ -2,12 +2,12 @@
 # Providers
 # ------------------------------------------------------------------------------
 terraform {
-  required_version = ">= 0.13.0, < 0.14"
+  required_version = ">= 1.3, < 1.4"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 0.3, < 4.0"
+      version = ">= 5.0, < 6.0"
     }
     vault = {
       source  = "hashicorp/vault"

--- a/groups/unifiedmanager/s3.tf
+++ b/groups/unifiedmanager/s3.tf
@@ -1,6 +1,6 @@
 module "aiqum_backup_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "3.0.1"
+  version = "~> 4.7.0"
 
   bucket = "${var.aws_account}.${var.aws_region}.aiqum.ch.gov.uk"
   acl    = "private"


### PR DESCRIPTION
This refactor supersedes the changes in #191 and includes the following:

- Updated `terraform-aws-modules/security-group/aws`, `terraform-aws-modules/s3-bucket/aws` and `companieshouse/terraform-modules` modules to latest versions
- Updated `hashicorp/aws` provider to latest version
- Updated Terraform version constraint
- Refactored deprecated functions and attributes (`map` -> `tomap`, `enable_SSM` -> `enable_ssm`)
- Switched from CIDR blocks to VPC prefix list for administrative security group rules
- Added ingress rules for syslog service (`514/tcp`, `514/udp`)
- Formatted source files (`terraform fmt`)