### PR TITLE
Duplicate connector code for version migration

### DIFF
--- a/groups/connector-v2/README.md
+++ b/groups/connector-v2/README.md
@@ -1,8 +1,8 @@
-# NetApp Cloud Manager Connector
+# NetApp Cloud Manager Connector V2
 
-This is the original version of the Connector module which has now been superceded
-by `connector-v2`. This module remains whilst the original resources are still in
-place, but should be removed once they have been retired.
+This module serves to replace the original version of the Connector. A new implementation
+of the module has been included to allow migration from the old implementation without
+disturbing the existing codebase/resources as part of troubleshooting reliability issues.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements

--- a/groups/connector-v2/data.tf
+++ b/groups/connector-v2/data.tf
@@ -33,6 +33,18 @@ data "vault_generic_secret" "netapp_connector_input" {
   path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/connector-inputs"
 }
 
+data "vault_generic_secret" "netapp_cvo_cidrs" {
+  path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/cvo-cidrs"
+}
+
+data "vault_generic_secret" "netapp_cvo_hosts" {
+  path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/cvo-hosts"
+}
+
+data "vault_generic_secret" "netapp_iboss_cidrs" {
+  path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/iboss-cidrs"
+}
+
 data "aws_instance" "netapp_connector" {
   filter {
     name   = "tag:Name"

--- a/groups/connector-v2/data.tf
+++ b/groups/connector-v2/data.tf
@@ -36,7 +36,7 @@ data "vault_generic_secret" "netapp_connector_input" {
 data "aws_instance" "netapp_connector" {
   filter {
     name   = "tag:Name"
-    values = ["${local.connector_name}-001"]
+    values = [local.connector_instance_name]
   }
 
   filter {

--- a/groups/connector-v2/data.tf
+++ b/groups/connector-v2/data.tf
@@ -1,0 +1,51 @@
+data "aws_vpc" "vpc" {
+  tags = {
+    Name = "vpc-${var.aws_account}"
+  }
+}
+
+data "aws_subnet_ids" "monitor" {
+  vpc_id = data.aws_vpc.vpc.id
+  filter {
+    name   = "tag:Name"
+    values = ["sub-monitor-*"]
+  }
+}
+
+data "aws_route53_zone" "private_zone" {
+  name         = local.internal_fqdn
+  private_zone = true
+}
+
+data "vault_generic_secret" "account_ids" {
+  path = "aws-accounts/account-ids"
+}
+
+data "vault_generic_secret" "internal_cidrs" {
+  path = "aws-accounts/network/internal_cidr_ranges"
+}
+
+data "vault_generic_secret" "netapp_account" {
+  path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/account"
+}
+
+data "vault_generic_secret" "netapp_connector_input" {
+  path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/connector-inputs"
+}
+
+data "aws_instance" "netapp_connector" {
+  filter {
+    name   = "tag:Name"
+    values = ["${local.connector_name}-001"]
+  }
+
+  filter {
+    name   = "instance-state-name"
+    values = ["running"]
+  }
+
+
+  depends_on = [
+    module.netapp_connector
+  ]
+}

--- a/groups/connector-v2/locals.tf
+++ b/groups/connector-v2/locals.tf
@@ -1,0 +1,19 @@
+# ------------------------------------------------------------------------
+# Locals
+# ------------------------------------------------------------------------
+locals {
+  account_ids                 = data.vault_generic_secret.account_ids.data
+  admin_cidrs                 = values(data.vault_generic_secret.internal_cidrs.data)
+  netapp_account_data         = data.vault_generic_secret.netapp_account.data
+  netapp_connector_input_data = data.vault_generic_secret.netapp_connector_input.data
+
+  internal_fqdn = "${replace(var.aws_account, "-", "")}.aws.internal"
+
+  connector_name = "${var.application}-connector-v2"
+
+  default_tags = {
+    Terraform = "true"
+    Project   = var.account
+    Region    = var.aws_region
+  }
+}

--- a/groups/connector-v2/locals.tf
+++ b/groups/connector-v2/locals.tf
@@ -4,6 +4,9 @@
 locals {
   account_ids                 = data.vault_generic_secret.account_ids.data
   admin_cidrs                 = values(data.vault_generic_secret.internal_cidrs.data)
+  cvo_cidrs                   = values(data.vault_generic_secret.netapp_cvo_cidrs.data)
+  cvo_hosts                   = values(data.vault_generic_secret.netapp_cvo_hosts.data)
+  iboss_cidrs                 = values(data.vault_generic_secret.netapp_iboss_cidrs.data)
   netapp_account_data         = data.vault_generic_secret.netapp_account.data
   netapp_connector_input_data = data.vault_generic_secret.netapp_connector_input.data
 

--- a/groups/connector-v2/locals.tf
+++ b/groups/connector-v2/locals.tf
@@ -10,6 +10,7 @@ locals {
   internal_fqdn = "${replace(var.aws_account, "-", "")}.aws.internal"
 
   connector_name = "${var.application}-connector-v2"
+  connector_instance_name = "${local.connector_name}-001"
 
   default_tags = {
     Terraform = "true"

--- a/groups/connector-v2/main.tf
+++ b/groups/connector-v2/main.tf
@@ -15,7 +15,7 @@ terraform {
     }
     netapp-cloudmanager = {
       source  = "NetApp/netapp-cloudmanager"
-      version = "25.3.0"
+      version = "24.5.0"
     }
   }
   backend "s3" {}

--- a/groups/connector-v2/main.tf
+++ b/groups/connector-v2/main.tf
@@ -1,0 +1,39 @@
+# ------------------------------------------------------------------------------
+# Providers
+# ------------------------------------------------------------------------------
+terraform {
+  required_version = ">= 0.13.0, < 0.14"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 0.3, < 4.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = ">= 2.0.0"
+    }
+    netapp-cloudmanager = {
+      source  = "NetApp/netapp-cloudmanager"
+      version = "25.3.0"
+    }
+  }
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+provider "vault" {
+  auth_login {
+    path = "auth/userpass/login/${var.vault_username}"
+    parameters = {
+      password = var.vault_password
+    }
+  }
+}
+
+provider "netapp-cloudmanager" {
+  refresh_token = local.netapp_account_data["refresh-token"]
+}

--- a/groups/connector-v2/netapp.tf
+++ b/groups/connector-v2/netapp.tf
@@ -1,0 +1,59 @@
+resource "aws_key_pair" "netapp" {
+  key_name   = local.connector_name
+  public_key = local.netapp_connector_input_data["public-key"]
+}
+
+module "netapp_connector" {
+  source = "git::git@github.com:companieshouse/terraform-modules//aws/netapp_cloudmanager_connector_aws?ref=tags/1.0.271"
+
+  name          = format("%s-%s", local.connector_name, "001")
+  vpc_id        = data.aws_vpc.vpc.id
+  company_name  = var.cloud_manager_company_name
+  instance_type = var.cloud_manager_instance_type
+  subnet_id     = coalesce(data.aws_subnet_ids.monitor.ids...)
+  set_public_ip = var.cloud_manager_set_public_ip
+  key_pair_name = aws_key_pair.netapp.key_name
+
+  # Set to false because of an issue with the app level connector service, terraform wants to build a new one which we do not want
+  build_connector   = false
+  netapp_account_id = local.netapp_account_data["account-id"]
+  netapp_cvo_accountIds = [
+    local.account_ids["heritage-development"],
+    local.account_ids["heritage-staging"],
+    local.account_ids["heritage-live"],
+    local.account_ids["finance-development"],
+    local.account_ids["finance-staging"],
+    local.account_ids["finance-live"]
+  ]
+
+  cvo_connector_role_names = var.cvo_connector_role_names
+
+  ingress_ports = var.cloud_manager_ingress_ports
+
+  egress_ports = var.cloud_manager_egress_ports
+
+  ingress_cidr_blocks = concat(
+    local.admin_cidrs
+  )
+
+  egress_cidr_blocks = ["0.0.0.0/0"]
+
+  tags = merge(
+    local.default_tags,
+    map(
+      "Account", var.aws_account,
+      "ServiceTeam", "Storage"
+    )
+  )
+}
+
+resource "aws_security_group_rule" "cvo_ingress" {
+  security_group_id = module.netapp_connector.occm_security_group_id
+  description       = "Allow CVO clusters to communicate with Connector for updates"
+
+  type        = "ingress"
+  from_port   = 80
+  to_port     = 80
+  protocol    = "tcp"
+  cidr_blocks = var.cvo_ranges
+}

--- a/groups/connector-v2/netapp.tf
+++ b/groups/connector-v2/netapp.tf
@@ -6,7 +6,7 @@ resource "aws_key_pair" "netapp" {
 module "netapp_connector" {
   source = "git::git@github.com:companieshouse/terraform-modules//aws/netapp_cloudmanager_connector_aws?ref=tags/1.0.271"
 
-  name          = format("%s-%s", local.connector_name, "001")
+  name          = local.connector_instance_name
   vpc_id        = data.aws_vpc.vpc.id
   company_name  = var.cloud_manager_company_name
   instance_type = var.cloud_manager_instance_type

--- a/groups/connector-v2/netapp.tf
+++ b/groups/connector-v2/netapp.tf
@@ -15,7 +15,7 @@ module "netapp_connector" {
   key_pair_name = aws_key_pair.netapp.key_name
 
   # Set to false because of an issue with the app level connector service, terraform wants to build a new one which we do not want
-  build_connector   = false
+  build_connector   = true
   netapp_account_id = local.netapp_account_data["account-id"]
   netapp_cvo_accountIds = [
     local.account_ids["heritage-development"],

--- a/groups/connector-v2/netapp.tf
+++ b/groups/connector-v2/netapp.tf
@@ -33,7 +33,8 @@ module "netapp_connector" {
   egress_ports = var.cloud_manager_egress_ports
 
   ingress_cidr_blocks = concat(
-    local.admin_cidrs
+    local.admin_cidrs,
+    local.iboss_cidrs
   )
 
   egress_cidr_blocks = ["0.0.0.0/0"]
@@ -55,5 +56,16 @@ resource "aws_security_group_rule" "cvo_ingress" {
   from_port   = 80
   to_port     = 80
   protocol    = "tcp"
-  cidr_blocks = var.cvo_ranges
+  cidr_blocks = local.cvo_cidrs
+}
+
+resource "aws_security_group_rule" "cvo_ingress_hosts" {
+  security_group_id = module.netapp_connector.occm_security_group_id
+  description       = "Allow CVO hosts to communicate with Connector for updates"
+
+  type        = "ingress"
+  from_port   = 80
+  to_port     = 80
+  protocol    = "tcp"
+  cidr_blocks = local.cvo_hosts
 }

--- a/groups/connector-v2/netapp.tf
+++ b/groups/connector-v2/netapp.tf
@@ -4,7 +4,7 @@ resource "aws_key_pair" "netapp" {
 }
 
 module "netapp_connector" {
-  source = "git::git@github.com:companieshouse/terraform-modules//aws/netapp_cloudmanager_connector_aws?ref=tags/1.0.271"
+  source = "git::git@github.com:companieshouse/terraform-modules//aws/netapp_cloudmanager_connector_aws?ref=tags/1.0.321"
 
   name          = local.connector_instance_name
   vpc_id        = data.aws_vpc.vpc.id

--- a/groups/connector-v2/profiles/shared-services-eu-west-2/vars
+++ b/groups/connector-v2/profiles/shared-services-eu-west-2/vars
@@ -21,19 +21,6 @@ cloud_manager_egress_ports = [
     { "protocol" = "-1", "port" = 0 },
   ]
 
-# CVO
-cvo_ranges = [
-    "10.104.9.64/26",
-    "10.104.9.128/26",
-    "10.104.9.192/26",
-    "10.94.9.64/26",
-    "10.94.9.128/26",
-    "10.94.9.192/26",
-    "10.84.9.64/26",
-    "10.84.9.128/26",
-    "10.84.9.192/26"
-]
-
 cvo_connector_role_names = [
   "irol-netapp-connector-build",
   "irol-connector-netapp-finance",

--- a/groups/connector-v2/profiles/shared-services-eu-west-2/vars
+++ b/groups/connector-v2/profiles/shared-services-eu-west-2/vars
@@ -1,0 +1,41 @@
+aws_region  = "eu-west-2"
+aws_account = "shared-services"
+
+# shorthand
+account = "shared"
+region  = "euw2"
+
+# Application
+application = "netapp"
+
+# NetApp Connector
+cloud_manager_instance_type = "t3.2xlarge"
+cloud_manager_company_name = "companieshouse"
+cloud_manager_ingress_ports = [
+    { "protocol" = "tcp", "port" = 22 },
+    { "protocol" = "tcp", "port" = 80 },
+    { "protocol" = "tcp", "port" = 443 },
+  ]
+
+cloud_manager_egress_ports = [
+    { "protocol" = "-1", "port" = 0 },
+  ]
+
+# CVO
+cvo_ranges = [
+    "10.104.9.64/26",
+    "10.104.9.128/26",
+    "10.104.9.192/26",
+    "10.94.9.64/26",
+    "10.94.9.128/26",
+    "10.94.9.192/26",
+    "10.84.9.64/26",
+    "10.84.9.128/26",
+    "10.84.9.192/26"
+]
+
+cvo_connector_role_names = [
+  "irol-netapp-connector-build",
+  "irol-connector-netapp-finance",
+  "irol-connector-netapp-new"
+]

--- a/groups/connector-v2/route53.tf
+++ b/groups/connector-v2/route53.tf
@@ -1,0 +1,7 @@
+resource "aws_route53_record" "netapp_connector" {
+  zone_id = data.aws_route53_zone.private_zone.zone_id
+  name    = local.connector_name
+  type    = "A"
+  ttl     = "300"
+  records = [data.aws_instance.netapp_connector.private_ip]
+}

--- a/groups/connector-v2/variables.tf
+++ b/groups/connector-v2/variables.tf
@@ -65,14 +65,6 @@ variable "cloud_manager_egress_ports" {
 }
 
 # ------------------------------------------------------------------------------
-# NetApp CVO variablesg
-# ------------------------------------------------------------------------------
-variable "cvo_ranges" {
-  type        = list(string)
-  description = "A list of subnets that contain CVO infrastructure"
-}
-
-# ------------------------------------------------------------------------------
 # NetApp CVO IAM roles names
 # ------------------------------------------------------------------------------
 variable "cvo_connector_role_names" {

--- a/groups/connector-v2/variables.tf
+++ b/groups/connector-v2/variables.tf
@@ -1,0 +1,81 @@
+
+# ------------------------------------------------------------------------------
+# AWS Variables
+# ------------------------------------------------------------------------------
+variable "account" {
+  type        = string
+  description = "The shorthand for the AWS account"
+}
+
+variable "aws_account" {
+  type        = string
+  description = "The AWS account in which resources will be administered"
+}
+
+variable "aws_region" {
+  type        = string
+  description = "The AWS region in which resources will be administered"
+}
+
+variable "region" {
+  type        = string
+  description = "The shorthand for the AWS region"
+}
+
+variable "vault_username" {
+  type        = string
+  description = "Username for connecting to Vault"
+}
+
+variable "vault_password" {
+  type        = string
+  description = "Password for connecting to Vault"
+}
+
+variable "application" {
+  type        = string
+  description = "Name for the application being deployed"
+}
+
+# ------------------------------------------------------------------------------
+# NetApp Cloud Manager Variables
+# ------------------------------------------------------------------------------
+variable "cloud_manager_instance_type" {
+  type        = string
+  description = "instance type to be used for the NetApp Cloud Manager EC2 instance"
+}
+
+variable "cloud_manager_company_name" {
+  type        = string
+  description = "Company name string to be passed to NetApp module for naming and setup of Cloud Manager"
+}
+
+variable "cloud_manager_set_public_ip" {
+  type        = string
+  description = "Set a public IP on the NetApp Cloud Manager instance"
+  default     = false
+}
+
+variable "cloud_manager_ingress_ports" {
+  description = "List object containg protocol, port and optional to_port"
+}
+
+variable "cloud_manager_egress_ports" {
+  description = "List object containg protocol, port and optional to_port"
+}
+
+# ------------------------------------------------------------------------------
+# NetApp CVO variablesg
+# ------------------------------------------------------------------------------
+variable "cvo_ranges" {
+  type        = list(string)
+  description = "A list of subnets that contain CVO infrastructure"
+}
+
+# ------------------------------------------------------------------------------
+# NetApp CVO IAM roles names
+# ------------------------------------------------------------------------------
+variable "cvo_connector_role_names" {
+  type        = list(string)
+  description = "A list of CVO connector IAM role names to that the connector will be permitted to assume"
+}


### PR DESCRIPTION
Due to connnectivity/reliability issues with the existing NetApp CloudManager Connector, adding a duplicate module to address the version/capacity support requirements mandated by NetApp and deploy a separate Connector instance, without disturbing the existing module/resources:

* create a new connector-v2 group
* rework some of the variables/configuration values so can be changed from single distinct local variables
* updated the NetApp CloudManager provider to the latest supported version for TF 0.13
* updated the netapp_cloudmanager_connector_aws to the latest version
* reworked and updated the SG configuration to move all values into Vault and capture some previous unmanaged manual modifcations that have been made in AWS