### PR TITLE
Revert build_connector Connector conditional

### DIFF
--- a/groups/connector-v2/netapp.tf
+++ b/groups/connector-v2/netapp.tf
@@ -15,7 +15,7 @@ module "netapp_connector" {
   key_pair_name = aws_key_pair.netapp.key_name
 
   # Set to false because of an issue with the app level connector service, terraform wants to build a new one which we do not want
-  build_connector   = true
+  build_connector   = false
   netapp_account_id = local.netapp_account_data["account-id"]
   netapp_cvo_accountIds = [
     local.account_ids["heritage-development"],


### PR DESCRIPTION
The newly added connector-v2 need the build_connector conditional switching to true to allow the connnector to be provisioned.

Reverting to false to match the state of the old version of the connector code.