### PR TITLE
Pin ami version and prevent data volume destroy

### DIFF
--- a/groups/snapcenter/instance.tf
+++ b/groups/snapcenter/instance.tf
@@ -76,6 +76,11 @@ resource "aws_ebs_volume" "snapcenter_data" {
     Backup     = true
     Purpose    = "SnapCenter Installation and Data"
   })
+
+  lifecycle {
+    ignore_changes  = [snapshot_id]
+    prevent_destroy = true
+  }
 }
 
 resource "aws_volume_attachment" "snapcenter_data" {

--- a/groups/snapcenter/profiles/finance-live-eu-west-2/live/vars
+++ b/groups/snapcenter/profiles/finance-live-eu-west-2/live/vars
@@ -8,3 +8,6 @@ environment = "live"
 ### default = root_volume_size = 100
 ### default = snapcenter_data_volume_size = 200
 ### default = default_log_retention_in_days = "7"
+
+# AMI
+ami_version_pattern = "0.1.4"

--- a/groups/snapcenter/profiles/finance-staging-eu-west-2/staging/vars
+++ b/groups/snapcenter/profiles/finance-staging-eu-west-2/staging/vars
@@ -8,3 +8,6 @@ environment = "staging"
 ### default = root_volume_size = 100
 ### default = snapcenter_data_volume_size = 200
 ### default = default_log_retention_in_days = "7"
+
+# AMI
+ami_version_pattern = "0.1.4"

--- a/groups/snapcenter/profiles/heritage-development-eu-west-2/development/vars
+++ b/groups/snapcenter/profiles/heritage-development-eu-west-2/development/vars
@@ -8,3 +8,6 @@ environment = "development"
 ### default = root_volume_size = 100
 ### default = snapcenter_data_volume_size = 200
 ### default = default_log_retention_in_days = "7"
+
+# AMI
+ami_version_pattern = "0.1.4"

--- a/groups/snapcenter/profiles/heritage-live-eu-west-2/live/vars
+++ b/groups/snapcenter/profiles/heritage-live-eu-west-2/live/vars
@@ -8,3 +8,6 @@ environment = "live"
 ### default = root_volume_size = 100
 ### default = snapcenter_data_volume_size = 200
 ### default = default_log_retention_in_days = "7"
+
+# AMI
+ami_version_pattern = "0.1.4"

--- a/groups/snapcenter/profiles/heritage-staging-eu-west-2/staging/vars
+++ b/groups/snapcenter/profiles/heritage-staging-eu-west-2/staging/vars
@@ -8,3 +8,6 @@ environment = "staging"
 ### default = root_volume_size = 100
 ### default = snapcenter_data_volume_size = 200
 ### default = default_log_retention_in_days = "7"
+
+# AMI
+ami_version_pattern = "0.1.4"


### PR DESCRIPTION
Terraform runner shows a clean plan:
Plan: 15 to add, 0 to change, 0 to destroy. when run fresh in h-dev

This pins the ami version for latest, as the intention is for future upgrades to be made in place (using ansible).

As an extra safety step, I've added explicit destory prevention on the data disk.

To note, the ansible upgrade also takes a snapshot before updating the system.