### PR TITLE
disable tenable cwp scan

### DIFF
--- a/groups/cvo-finance/netapp.tf
+++ b/groups/cvo-finance/netapp.tf
@@ -42,7 +42,9 @@ module "cvo2" {
     local.default_tags,
     tomap(
       {
-        ServiceTeam = "Storage"
+        ServiceTeam               = "Storage"
+        tenable-cwp-scan-disabled = "true"
+        Repository                = "netapp-terraform"
       }
     )
   )

--- a/groups/cvo/netapp.tf
+++ b/groups/cvo/netapp.tf
@@ -38,6 +38,8 @@ module "cvo" {
     local.default_tags,
     map(
       "ServiceTeam", "Storage"
+      "tenable-cwp-scan-disabled", "true"
+      "Repository", "netapp-terraform"
     )
   )
 }


### PR DESCRIPTION
This is for [DVOP-4517](https://companieshouse.atlassian.net/browse/DVOP-4517)

There is an issue where workload scanning cannot run on certain instances either due to licensing restrictions or the workload doesn't support the scanner.

Once they have been excluded, inspector will be ingested into tenable ([DVOP-4853](https://companieshouse.atlassian.net/browse/DVOP-4853)) instead to restore the data and circumvent the workload scanning issues

[DVOP-4517]: https://companieshouse.atlassian.net/browse/DVOP-4517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DVOP-4853]: https://companieshouse.atlassian.net/browse/DVOP-4853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ